### PR TITLE
fix `ifm make`, add support for params and str in action.name of IFD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Function `run` can not remove the indent of code.
 - Clear input buffer after printing story.
+- Function `make` can not generate right item file.
 
 ## [v0.1.1] - 2019-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Modules can contain a `config.yml` file.
+- Action names can contain `[]` to match any string.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Function `run` can not remove the indent of code.
 - Clear input buffer after printing story.
-- Function `make` can not generate right item file.
+- Function `make` can not generate the right item file.
 
 ## [v0.1.1] - 2019-07-18
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,3 +4,4 @@
 - Chain command parsing.
 - IFT include many files in one line.
 - Download ifm from pypi.
+- Command name can accept many classes.

--- a/ifm.py
+++ b/ifm.py
@@ -45,6 +45,7 @@ def processActionName(data: dict) -> None:
 			for action in data[itemID]['actions']:
 				result = []
 				action['name'] = removeInnerWhiteChars(action['name'], '(', ')')
+				action['name'] = removeInnerWhiteChars(action['name'], '[', ']')
 				result = action['name'].split()
 				for i in range(len(result)):
 					if result[i] == 'this':

--- a/src/data.py
+++ b/src/data.py
@@ -15,13 +15,15 @@ items = refdict({})
 game = refdict({})
 completer = set()
 
-def findItem(itemName: str):
+def findItem(itemName: str, className = ''):
 	'''
 	return item ID. if item ID is not found, return None
+
+	`className` is a class name
 	'''
 	global items
 	for itemID in items:
-		if items[itemID]["name"] == itemName:
+		if items[itemID]["name"] == itemName and className in items[itemID]['classes']:
 			return itemID
 	return None
 


### PR DESCRIPTION
## Fixed

- Command `ifm make` can not generate the right item file.

## Added

- The shell can parse actions with params in `()` and any string in `[]`.