### PR TITLE
fix story.__parseElement()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Clear input buffer after printing story.
 - Function `make` can not generate the right item file.
 - Function `load` will break data consistency.
+- Pressing `ESC` can not skip complex stories with many tags.
 
 ## [v0.1.1] - 2019-07-18
 

--- a/src/story.py
+++ b/src/story.py
@@ -104,10 +104,10 @@ def __parseElement(el: ElementTree.Element, skip: bool) -> bool:
 	# TODO: add element support: else/elif/switch/case
 	if el.tag == 'if':
 		if eval(el.get('condition')):
-			__printElement(el)
+			skip = __printElement(el, skip)
 	elif el.tag == 'while':
 		while eval(el.get('condition')):
-			__printElement(el)
+			skip = __printElement(el, skip)
 	elif el.tag == 'input':
 		if el.get('prompt'):
 			printf(el.get('prompt'), skip = skip, end = '')
@@ -115,6 +115,7 @@ def __parseElement(el: ElementTree.Element, skip: bool) -> bool:
 	elif el.tag == 'code':
 		from translator import run
 		run(el.text, localData)
+	return skip
 
 def printItemList(l: list, skip = True, indent = '- ', sep = '\n', end = '\n'):
 	'''


### PR DESCRIPTION
Now pressing `ESC` can skip complex stories with many tags.