### PR TITLE
fix story.printItemList()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Function `make` can not generate the right item file.
 - Function `load` will break data consistency.
 - Pressing `ESC` can not skip complex stories with many tags.
+- Function `printItemList` went wrong if the size of item list is bigger than two.
 
 ## [v0.1.1] - 2019-07-18
 

--- a/src/story.py
+++ b/src/story.py
@@ -127,7 +127,7 @@ def printItemList(l: list, skip = True, indent = '- ', sep = '\n', end = '\n'):
 			itemID = itemID[1:]
 		printf(data.items[itemID]['name'], skip=skip, indent=indent, end='')
 		if i != len(l) - 1:
-			print(sep, skip = skip, end = '')
+			printf(sep, skip = skip, end = '')
 	printf(end, skip=skip, end='')
 
 def flush_input():


### PR DESCRIPTION
fix: Function `printItemList` went wrong if the size of the item list is bigger than two